### PR TITLE
Fix chealpix transitive

### DIFF
--- a/apps/ExtPointBinding/CMakeLists.txt
+++ b/apps/ExtPointBinding/CMakeLists.txt
@@ -12,7 +12,4 @@ set(Demo_ExtPointBinding_SRC
 add_executable(${PROJECT_NAME} ${Demo_ExtPointBinding_SRC})
 target_link_libraries(${PROJECT_NAME} gr::utils gr::accel gr::algo gr::io)
 add_dependencies(${PROJECT_NAME} opengr)
-if(OpenGR_USE_CHEALPIX)
-    target_link_libraries(${PROJECT_NAME} chealpix)
-endif(OpenGR_USE_CHEALPIX)
 install( TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin  )

--- a/apps/PCLWrapper/CMakeLists.txt
+++ b/apps/PCLWrapper/CMakeLists.txt
@@ -12,7 +12,8 @@ if( PCL_FOUND )
 
   include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
   add_executable(${PROJECT_NAME} ${Demo_PCL_SRC} ${Demo_PCL_headers})
-  target_link_libraries(${PROJECT_NAME} gr::algo gr::utils ${PCL_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME} gr::algo gr::utils gr::accel ${PCL_LIBRARIES})
+  add_dependencies(${PROJECT_NAME} opengr)
 
   # [C/C++]>[General]>[Additional Include Directories]
   include_directories( ${PCL_INCLUDE_DIRS} )

--- a/apps/Super4PCS/CMakeLists.txt
+++ b/apps/Super4PCS/CMakeLists.txt
@@ -7,7 +7,4 @@ set(Demo_Super4PCS_SRC
 add_executable(${PROJECT_NAME} ${Demo_Super4PCS_SRC})
 target_link_libraries(${PROJECT_NAME} gr::utils gr::accel gr::algo gr::io)
 add_dependencies(${PROJECT_NAME} opengr)
-if(OpenGR_USE_CHEALPIX)
-    target_link_libraries(${PROJECT_NAME} chealpix)
-endif(OpenGR_USE_CHEALPIX)
 install( TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin  )

--- a/src/gr/accelerators/CMakeLists.txt
+++ b/src/gr/accelerators/CMakeLists.txt
@@ -40,6 +40,7 @@ set_target_properties(accel PROPERTIES
 
 if(OpenGR_USE_CHEALPIX)
     add_dependencies(accel chealpix)
+    target_link_libraries(accel INTERFACE chealpix)
 endif(OpenGR_USE_CHEALPIX)
 
 set(targets_export_name "${PROJECT_NAME}Targets")

--- a/src/gr/algorithms/CMakeLists.txt
+++ b/src/gr/algorithms/CMakeLists.txt
@@ -23,11 +23,6 @@ set_target_properties(algo PROPERTIES
   INTERFACE_COMPILE_FEATURES cxx_std_17
 )
 
-if(OpenGR_USE_CHEALPIX)
-    include_directories(${Chealpix_INCLUDE_DIR})
-    add_dependencies(algo chealpix)
-endif(OpenGR_USE_CHEALPIX)
-
 set(targets_export_name "${PROJECT_NAME}Targets")
 install( TARGETS algo
     EXPORT "${targets_export_name}"


### PR DESCRIPTION
Fix missing link between `gr::accel` and chealpix.

With this fix, chealpix is exported as a dependency of `gr::accel`, which allows transitive linking (ie. the apps does not need to explicitly link with chealpix).