### PR TITLE
Add getters + setters to PCL Wrapper.

### DIFF
--- a/apps/PCLWrapper/main.cpp
+++ b/apps/PCLWrapper/main.cpp
@@ -98,7 +98,8 @@ main (int argc, char **argv)
     }
 
   pcl::Super4PCS<PointNT,PointNT> align;
-  Demo::setOptionsFromArgs(align.options_);
+  auto options = align.getOptions();
+  Demo::setOptionsFromArgs(options);
 
   // Perform alignment
   pcl::console::print_highlight ("Starting alignment...\n");

--- a/apps/PCLWrapper/main.cpp
+++ b/apps/PCLWrapper/main.cpp
@@ -98,7 +98,7 @@ main (int argc, char **argv)
     }
 
   pcl::Super4PCS<PointNT,PointNT> align;
-  auto options = align.getOptions();
+  auto &options = align.getOptions();
   Demo::setOptionsFromArgs(options);
 
   // Perform alignment

--- a/apps/PCLWrapper/pcl/registration/impl/super4pcs.hpp
+++ b/apps/PCLWrapper/pcl/registration/impl/super4pcs.hpp
@@ -77,7 +77,7 @@ pcl::Super4PCS<PointSource, PointTarget>::computeTransformation (PointCloudSourc
   fillPointSet(*target_, set1);
   fillPointSet(*input_, set2);;
 
-  fitness_score_ = matcher.ComputeTransformation(set1, set2, final_transformation_, sampler, visitor);
+  float score = matcher.ComputeTransformation(set1, set2, final_transformation_, sampler, visitor);
 
   transformPointCloud (*input_, output, final_transformation_);
 

--- a/apps/PCLWrapper/pcl/registration/impl/super4pcs.hpp
+++ b/apps/PCLWrapper/pcl/registration/impl/super4pcs.hpp
@@ -77,7 +77,7 @@ pcl::Super4PCS<PointSource, PointTarget>::computeTransformation (PointCloudSourc
   fillPointSet(*target_, set1);
   fillPointSet(*input_, set2);;
 
-  float score = matcher.ComputeTransformation(set1, set2, final_transformation_, sampler, visitor);
+  fitness_score_ = matcher.ComputeTransformation(set1, set2, final_transformation_, sampler, visitor);
 
   transformPointCloud (*input_, output, final_transformation_);
 

--- a/apps/PCLWrapper/pcl/registration/super4pcs.h
+++ b/apps/PCLWrapper/pcl/registration/super4pcs.h
@@ -124,8 +124,6 @@ namespace pcl
       using MatcherType   = gr::Match4pcsBase<gr::FunctorSuper4PCS, PointType, TransformVisitor, gr::AdaptivePointFilter, gr::AdaptivePointFilter::Options>;
       using OptionType    = typename MatcherType::OptionsType;
 
-      OptionType options_;
-
       /** \brief Constructor */
       Super4PCS ()
       {
@@ -137,12 +135,27 @@ namespace pcl
       virtual ~Super4PCS ()
       {
       }
+      
+      /** \brief Setter for the delta (see paper).
+       */
+      inline void setDelta(float delta) { options_.delta = delta; }
+      inline void setSampleSize(int sampleSize) { options_.sample_size = sampleSize; }
+      inline void setMaxTimeSeconds(float seconds) { options_.max_time_seconds = seconds; }
+      inline void setOverlap(float overlap) { options_.configureOverlap(overlap); }
 
       /** \brief Get the fitness score of alignment. Range from 0-1, higher is better.
        */
       inline float getFitnessScore() const { return fitness_score_; }
+      inline float getDelta() const { return options_.delta; }
+      inline int getSampleSize() const { return options_.sample_size; }
+      inline float getMaxTimeSeconds() const { return options_.max_time_seconds; }
+      inline float getOverlap() const { return options_.getOverlapEstimation(); }
+      
+      inline OptionType getOptions() const { return options_; }
 
     protected:
+
+      OptionType options_;
 
       float fitness_score_;
 

--- a/apps/PCLWrapper/pcl/registration/super4pcs.h
+++ b/apps/PCLWrapper/pcl/registration/super4pcs.h
@@ -151,7 +151,8 @@ namespace pcl
       inline float getMaxTimeSeconds() const { return options_.max_time_seconds; }
       inline float getOverlap() const { return options_.getOverlapEstimation(); }
       
-      inline OptionType getOptions() const { return options_; }
+      inline OptionType& getOptions()  { return options_; }
+      inline const OptionType& getOptions() const { return options_; }
 
     protected:
 
@@ -172,4 +173,3 @@ namespace pcl
 #endif
 
 #include <pcl/registration/impl/super4pcs.hpp>
-


### PR DESCRIPTION
Adds getters + setters for #55.

`s4pcs.options_` is still public, but the `main.cpp` needs to be changed for that (or, even better, `Demo::setOptionsFromArgs()` in `demo-utils.h` should be changed)