### PR TITLE
Update cmake minimal version (detect cxx_std_17)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.3)
+cmake_minimum_required (VERSION 3.8)
 project (OpenGR LANGUAGES CXX VERSION 1.2.0)
 
 ################################################################################


### PR DESCRIPTION
According to the documentation, cxx_std_17 has been introduced by cmake 3.8
https://cmake.org/cmake/help/v3.8/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html

This PR update cmake minimal version from 3.3 to 3.8 

Fixes cmake configuration error when using old version of cmake (see error report: https://github.com/STORM-IRIT/OpenGR/issues/61)