### PR TITLE
Add package.xml to simplify use in catkin workspaces

### DIFF
--- a/doc/Compilation.md
+++ b/doc/Compilation.md
@@ -90,6 +90,8 @@ They can be set either when calling CMake or globally by configuring Visual Stud
 ***
 
 ## <a name="usage"></a> Use OpenGR library in your own application
+
+### Using cmake
 **From release v.1.2**, OpenGR is now header-only, and provides a CMake package generated during the installation process.
 The target namespace is `gr`.
 
@@ -116,6 +118,9 @@ OpenGR files will be located in the `gr` folder. For instance, to use the Super4
 
 ```
 This functionality is tested by our continuous integration system. Checkout the [externalAppTest](https://github.com/STORM-IRIT/OpenGR/tree/master/tests/externalAppTest) for a working example.
+
+### Using in ROS (Robot Operating System)
+OpenGR includes a catkin [package files](http://wiki.ros.org/catkin/package.xml) to simplify use in ROS.
 
 ## <a name="perfs"></a> Debug mode and performances
 Note that we heavily use template mechanisms that requires to enable inlining in order to be efficient. Compiling in Debug mode without inlining may result in longer running time than expected.

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,13 @@
+<package format="2">
+  <name>opengr</name>
+  <version>1.2.0</version>
+  <description>OpenGR: A C++ library for 3D Global Registration</description>
+  <maintainer email="nmellado0@gmail.com">Nicolas Mellado</maintainer>
+  <license>Apache 2.0</license>
+  <buildtool_depend>cmake</buildtool_depend>
+  <!-- Following recommendations of REP 136 -->
+  <exec_depend>catkin</exec_depend>
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Mostly a convenience thing but this allows putting OpenGR into a catkin workspace as commonly used in ROS environments