### PR TITLE
Declare template template parameter declaration as class

### DIFF
--- a/src/gr/algorithms/congruentSetExplorationBase.h
+++ b/src/gr/algorithms/congruentSetExplorationBase.h
@@ -134,7 +134,7 @@ public:
     /// @return the computed LCP measure as a fraction of the size of P ([0..1]).
     template <typename InputRange1,
               typename InputRange2,
-              template<typename> typename Sampler>
+              template<typename> class Sampler>
     Scalar ComputeTransformation(const InputRange1& P,
                                  const InputRange2& Q,
                                  Eigen::Ref<MatrixType> transformation,

--- a/src/gr/algorithms/congruentSetExplorationBase.hpp
+++ b/src/gr/algorithms/congruentSetExplorationBase.hpp
@@ -56,7 +56,7 @@ CongruentSetExplorationBase<Traits, PointType, TransformVisitor, PairFilteringFu
 template <typename Traits, typename PointType, typename TransformVisitor,
           typename PairFilteringFunctor,
           template < class, class > class ... OptExts >
-template <typename InputRange1, typename InputRange2, template<typename> typename Sampler>
+template <typename InputRange1, typename InputRange2, template<typename> class Sampler>
 typename CongruentSetExplorationBase<Traits, PointType, TransformVisitor, PairFilteringFunctor, OptExts ...>::Scalar
 CongruentSetExplorationBase<Traits, PointType, TransformVisitor, PairFilteringFunctor, OptExts ...>::ComputeTransformation(
         const InputRange1& P,

--- a/src/gr/algorithms/match3pcs.h
+++ b/src/gr/algorithms/match3pcs.h
@@ -28,7 +28,7 @@ namespace gr {
     template <typename _PointType,
               typename _TransformVisitor,
               typename _PairFilteringFunctor,  /// <\brief Must implements PairFilterConcept
-              template < class, class > typename PairFilteringOptions >
+              template < class, class > class PairFilteringOptions >
     class Match3pcs : public CongruentSetExplorationBase<Traits3pcs<typename MatchBase<_PointType, _TransformVisitor, PairFilteringOptions, CongruentSetExplorationOptions>::PosMutablePoint>, _PointType, _TransformVisitor, _PairFilteringFunctor, PairFilteringOptions> {
     public:
       using PosMutablePoint      = typename MatchBase<_PointType, _TransformVisitor, PairFilteringOptions, CongruentSetExplorationOptions>::PosMutablePoint;

--- a/src/gr/algorithms/match3pcs.hpp
+++ b/src/gr/algorithms/match3pcs.hpp
@@ -15,7 +15,7 @@ namespace gr {
     template <typename PointType,
               typename TransformVisitor,
               typename PairFilteringFunctor,
-              template < class, class > typename PFO>
+              template < class, class > class PFO>
     Match3pcs<PointType, TransformVisitor, PairFilteringFunctor, PFO>::
     Match3pcs(const Match3pcs<PointType, TransformVisitor, PairFilteringFunctor, PFO>::OptionsType &options,
                          const gr::Utils::Logger &logger)
@@ -26,13 +26,13 @@ namespace gr {
     template <typename PointType,
               typename TransformVisitor,
               typename PairFilteringFunctor,
-              template < class, class > typename PFO>
+              template < class, class > class PFO>
     Match3pcs<PointType, TransformVisitor, PairFilteringFunctor, PFO>::~Match3pcs() {}
 
     template <typename PointType,
               typename TransformVisitor,
               typename PairFilteringFunctor,
-              template < class, class > typename PFO>
+              template < class, class > class PFO>
     bool Match3pcs<PointType, TransformVisitor, PairFilteringFunctor, PFO>::generateCongruents (CongruentBaseType &base, Set& congruent_set) {
 
         //Find base in P (random triangle)
@@ -91,7 +91,7 @@ namespace gr {
     template <typename PointType,
               typename TransformVisitor,
               typename PairFilteringFunctor,
-              template < class, class > typename PFO>
+              template < class, class > class PFO>
     bool Match3pcs<PointType, TransformVisitor, PairFilteringFunctor, PFO>::initBase (CongruentBaseType &base)
     {
         if (!MatchBaseType::SelectRandomTriangle(MatchBaseType::max_base_diameter_, base[0], base[1], base[2]))

--- a/src/gr/algorithms/match4pcsBase.h
+++ b/src/gr/algorithms/match4pcsBase.h
@@ -32,11 +32,11 @@ namespace gr {
 
     /// Class for the computation of the 4PCS algorithm.
     /// \param Functor use to determinate the use of Super4pcs or 4pcs algorithm.
-    template <template <typename, typename, typename> typename _Functor,
+    template <template <typename, typename, typename> class _Functor,
               typename _PointType,
               typename _TransformVisitor,
               typename _PairFilteringFunctor,  /// <\brief Must implements PairFilterConcept
-              template < class, class > typename PairFilteringOptions >
+              template < class, class > class PairFilteringOptions >
     class Match4pcsBase : public CongruentSetExplorationBase<Traits4pcs<typename MatchBase<_PointType, _TransformVisitor, PairFilteringOptions, CongruentSetExplorationOptions>::PosMutablePoint>, _PointType, _TransformVisitor, _PairFilteringFunctor, PairFilteringOptions> {
     public:
         using Scalar            = typename _PointType::Scalar;

--- a/src/gr/algorithms/match4pcsBase.hpp
+++ b/src/gr/algorithms/match4pcsBase.hpp
@@ -26,11 +26,11 @@
 
 
 namespace gr {
-    template <template <typename, typename, typename> typename _Functor,
+    template <template <typename, typename, typename> class _Functor,
               typename PointType,
               typename TransformVisitor,
               typename PairFilteringFunctor,
-              template < class, class > typename PFO>
+              template < class, class > class PFO>
     Match4pcsBase<_Functor, PointType, TransformVisitor, PairFilteringFunctor, PFO>::Match4pcsBase (const OptionsType& options
             , const Utils::Logger& logger)
             : MatchBaseType(options,logger)
@@ -38,18 +38,18 @@ namespace gr {
     {
     }
 
-    template <template <typename, typename, typename> typename _Functor,
+    template <template <typename, typename, typename> class _Functor,
               typename PointType,
               typename TransformVisitor,
               typename PairFilteringFunctor,
-              template < class, class > typename PFO>
+              template < class, class > class PFO>
     Match4pcsBase<_Functor, PointType, TransformVisitor, PairFilteringFunctor, PFO>::~Match4pcsBase() {}
 
-    template <template <typename, typename, typename> typename _Functor,
+    template <template <typename, typename, typename> class _Functor,
               typename PointType,
               typename TransformVisitor,
               typename PairFilteringFunctor,
-              template < class, class > typename PFO>
+              template < class, class > class PFO>
     bool Match4pcsBase<_Functor, PointType, TransformVisitor, PairFilteringFunctor, PFO>::TryQuadrilateral(
         typename PointType::Scalar &invariant1,
         typename PointType::Scalar &invariant2,
@@ -103,11 +103,11 @@ namespace gr {
         return true;
     }
 
-    template <template <typename, typename, typename> typename _Functor,
+    template <template <typename, typename, typename> class _Functor,
               typename PointType,
               typename TransformVisitor,
               typename PairFilteringFunctor,
-              template < class, class > typename PFO>
+              template < class, class > class PFO>
     bool Match4pcsBase<_Functor, PointType, TransformVisitor, PairFilteringFunctor, PFO>::SelectQuadrilateral(
         Scalar &invariant1,
         Scalar &invariant2,
@@ -183,22 +183,22 @@ namespace gr {
         return false;
     }
 
-    template <template <typename, typename, typename> typename _Functor,
+    template <template <typename, typename, typename> class _Functor,
               typename PointType,
               typename TransformVisitor,
               typename PairFilteringFunctor,
-              template < class, class > typename PFO>
+              template < class, class > class PFO>
     // Initialize all internal data structures and data members.
     void Match4pcsBase<_Functor, PointType, TransformVisitor, PairFilteringFunctor, PFO>::Initialize() {
         fun_.Initialize();
     }
 
 
-    template <template <typename, typename, typename> typename _Functor,
+    template <template <typename, typename, typename> class _Functor,
               typename PointType,
               typename TransformVisitor,
               typename PairFilteringFunctor,
-              template < class, class > typename PFO>
+              template < class, class > class PFO>
     bool Match4pcsBase<_Functor, PointType, TransformVisitor, PairFilteringFunctor, PFO>::generateCongruents (
         CongruentBaseType &base, Set& congruent_quads) {
 //      std::cout << "------------------" << std::endl;
@@ -247,11 +247,11 @@ namespace gr {
         return true;
     }
 
-    template <template <typename, typename, typename> typename _Functor,
+    template <template <typename, typename, typename> class _Functor,
               typename PointType,
               typename TransformVisitor,
               typename PairFilteringFunctor,
-              template < class, class > typename PFO>
+              template < class, class > class PFO>
     bool Match4pcsBase<_Functor, PointType, TransformVisitor, PairFilteringFunctor, PFO>::initBase (CongruentBaseType &base)
     {
         Scalar invariant1, invariant2; // dummy
@@ -259,11 +259,11 @@ namespace gr {
         return initBase(base, invariant1, invariant2);
     }
 
-    template <template <typename, typename, typename> typename _Functor,
+    template <template <typename, typename, typename> class _Functor,
               typename PointType,
               typename TransformVisitor,
               typename PairFilteringFunctor,
-              template < class, class > typename PFO>
+              template < class, class > class PFO>
     bool Match4pcsBase<_Functor, PointType, TransformVisitor, PairFilteringFunctor, PFO>::initBase (CongruentBaseType &base, Scalar& invariant1, Scalar& invariant2)
     {
         #ifdef STATIC_BASE
@@ -298,11 +298,11 @@ namespace gr {
     }
 
 
-    template <template <typename, typename, typename> typename _Functor,
+    template <template <typename, typename, typename> class _Functor,
               typename PointType,
               typename TransformVisitor,
               typename PairFilteringFunctor,
-              template < class, class > typename PFO>
+              template < class, class > class PFO>
     typename Match4pcsBase<_Functor, PointType, TransformVisitor, PairFilteringFunctor, PFO>::Scalar
     Match4pcsBase<_Functor, PointType, TransformVisitor, PairFilteringFunctor, PFO>::distSegmentToSegment(
         const VectorType& p1, const VectorType& p2,

--- a/src/gr/algorithms/matchBase.h
+++ b/src/gr/algorithms/matchBase.h
@@ -70,7 +70,7 @@ struct DummyTransformVisitor {
 
 /// \brief Abstract class for registration algorithms
 template <typename PointType, typename _TransformVisitor = DummyTransformVisitor,
-          template < class, class > typename ... OptExts>
+          template < class, class > class ... OptExts>
 class MatchBase {
 
 public:
@@ -262,7 +262,7 @@ protected :
     /// @param P The first input set.
     /// @param Q The second input set.
     /// @param sampler The sampler used to sample the input sets.
-    template <typename InputRange1, typename InputRange2, template<typename> typename Sampler>
+    template <typename InputRange1, typename InputRange2, template<typename> class Sampler>
     void init(const InputRange1& P,
               const InputRange2& Q,
               const Sampler<PointType>& sampler);

--- a/src/gr/algorithms/matchBase.hpp
+++ b/src/gr/algorithms/matchBase.hpp
@@ -27,7 +27,7 @@
 
 namespace gr {
 
-template <typename PointType, typename TransformVisitor, template < class, class > typename ... OptExts>
+template <typename PointType, typename TransformVisitor, template < class, class > class ... OptExts>
 MATCH_BASE_TYPE::MatchBase(const typename MATCH_BASE_TYPE::OptionsType &options,
                       const Utils::Logger& logger
                        )
@@ -36,11 +36,11 @@ MATCH_BASE_TYPE::MatchBase(const typename MATCH_BASE_TYPE::OptionsType &options,
     , options_(options)
 {}
 
-template <typename PointType, typename TransformVisitor, template < class, class > typename ... OptExts>
+template <typename PointType, typename TransformVisitor, template < class, class > class ... OptExts>
 MATCH_BASE_TYPE::~MatchBase(){}
 
 
-template <typename PointType, typename TransformVisitor, template < class, class > typename ... OptExts>
+template <typename PointType, typename TransformVisitor, template < class, class > class ... OptExts>
 typename MATCH_BASE_TYPE::Scalar
 MATCH_BASE_TYPE::MeanDistance() const {
     const Scalar kDiameterFraction = 0.2;
@@ -66,7 +66,7 @@ MATCH_BASE_TYPE::MeanDistance() const {
     return distance / number_of_samples;
 }
 
-template <typename PointType, typename TransformVisitor, template < class, class > typename ... OptExts>
+template <typename PointType, typename TransformVisitor, template < class, class > class ... OptExts>
 bool
 MATCH_BASE_TYPE::SelectRandomTriangle(Scalar max_base_diameter, int &base1, int &base2, int &base3) {
     int number_of_points = sampled_P_3D_.size();
@@ -104,7 +104,7 @@ MATCH_BASE_TYPE::SelectRandomTriangle(Scalar max_base_diameter, int &base1, int 
     return base1 != -1 && base2 != -1 && base3 != -1;
 }
 
-template <typename PointType, typename TransformVisitor, template < class, class > typename ... OptExts>
+template <typename PointType, typename TransformVisitor, template < class, class > class ... OptExts>
 void
 MATCH_BASE_TYPE::initKdTree(){
     size_t number_of_points = sampled_P_3D_.size();
@@ -119,7 +119,7 @@ MATCH_BASE_TYPE::initKdTree(){
 }
 
 
-template <typename PointType, typename TransformVisitor, template < class, class > typename ... OptExts>
+template <typename PointType, typename TransformVisitor, template < class, class > class ... OptExts>
 template <typename Coordinates>
 bool
 MATCH_BASE_TYPE::ComputeRigidTransformation(const Coordinates& ref,
@@ -256,8 +256,8 @@ MATCH_BASE_TYPE::ComputeRigidTransformation(const Coordinates& ref,
     return true;
 }
 
-template <typename PointType, typename TransformVisitor, template < class, class > typename ... OptExts>
-template <typename InputRange1, typename InputRange2, template<typename> typename Sampler>
+template <typename PointType, typename TransformVisitor, template < class, class > class ... OptExts>
+template <typename InputRange1, typename InputRange2, template<typename> class Sampler>
 void MATCH_BASE_TYPE::init(const InputRange1& P,
               const InputRange2& Q,
               const Sampler<PointType>& sampler) {


### PR DESCRIPTION
template template parameter declaration cannot be declared as typename before c++17, which might generate errors on old compilers (see #30)
Documentation: https://en.cppreference.com/w/cpp/language/template_parameters#Template_template_parameter