### PR TITLE
Bugfix where rotation matrix was being composed from non-normalized vectors, thus adding in scaling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ On-going
     - testing: simplify ctest configuration https://github.com/STORM-IRIT/OpenGR/pull/60
 
  - fixes
+    - Fix long-standing bug causing unexpected deformation of the registered point clouds https://github.com/STORM-IRIT/OpenGR/issues/9
     - Fix potential compilation error with compilers partially supporting cxx17 (gcc 4.9.2) https://github.com/STORM-IRIT/OpenGR/pull/66
     - Fix fitness score assignment in PCL wrapper https://github.com/STORM-IRIT/OpenGR/pull/65
     - update cmake minimal version (fixes #61) https://github.com/STORM-IRIT/OpenGR/pull/62

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -63,6 +63,7 @@ This library is based on [Super4PCS library](https://github.com/nmellado/Super4P
 * [Simone Gasparini](https://github.com/simogasp) Pull-Request reviews
 * [Kastan Day](https://github.com/kastanday) Added getFitnessScore() to PCL wrapper (#10)
 * [xinkang](https://github.com/xinkang) Fix include path of timer.h
+* [Patrick Beeson] (https://github.com/pbeeson) Fix composition of rotation matrix (#68)
 
 We also wish to thanks Simon Giraudot and https://geometryfactory.com/ for their support and help through our participation to
  - the 2019 Google Summer of Code: https://summerofcode.withgoogle.com/projects/#6321265885839360,

--- a/src/gr/algorithms/matchBase.hpp
+++ b/src/gr/algorithms/matchBase.hpp
@@ -179,6 +179,7 @@ MATCH_BASE_TYPE::ComputeRigidTransformation(const Coordinates& ref,
     if (vector_p2.squaredNorm() == 0) return std::numeric_limits<Scalar>::max();
     vector_p2.normalize();
     VectorType vector_p3 = vector_p1.cross(vector_p2);
+    if (vector_p3.squaredNorm() == 0) return std::numeric_limits<Scalar>::max();
     vector_p3.normalize();
 
     VectorType vector_q1 = q1 - q0;
@@ -188,6 +189,7 @@ MATCH_BASE_TYPE::ComputeRigidTransformation(const Coordinates& ref,
     if (vector_q2.squaredNorm() == 0) return std::numeric_limits<Scalar>::max();
     vector_q2.normalize();
     VectorType vector_q3 = vector_q1.cross(vector_q2);
+    if (vector_q3.squaredNorm() == 0) return std::numeric_limits<Scalar>::max();
     vector_q3.normalize();
 
     //cv::Mat rotation = cv::Mat::eye(3, 3, CV_64F);

--- a/src/gr/algorithms/matchBase.hpp
+++ b/src/gr/algorithms/matchBase.hpp
@@ -179,6 +179,7 @@ MATCH_BASE_TYPE::ComputeRigidTransformation(const Coordinates& ref,
     if (vector_p2.squaredNorm() == 0) return std::numeric_limits<Scalar>::max();
     vector_p2.normalize();
     VectorType vector_p3 = vector_p1.cross(vector_p2);
+    vector_p3.normalize();
 
     VectorType vector_q1 = q1 - q0;
     if (vector_q1.squaredNorm() == 0) return std::numeric_limits<Scalar>::max();
@@ -187,6 +188,7 @@ MATCH_BASE_TYPE::ComputeRigidTransformation(const Coordinates& ref,
     if (vector_q2.squaredNorm() == 0) return std::numeric_limits<Scalar>::max();
     vector_q2.normalize();
     VectorType vector_q3 = vector_q1.cross(vector_q2);
+    vector_q3.normalize();
 
     //cv::Mat rotation = cv::Mat::eye(3, 3, CV_64F);
     Eigen::Matrix<Scalar, 3, 3> rotation = Eigen::Matrix<Scalar, 3, 3>::Identity();


### PR DESCRIPTION
The norm of cross product between two vectors return the area of the parallelogram formed by these vectors, which is equal to 1 only if the two vectors are orthogonal.

I believe this might also need to be applied to the original Super4PCS code as well, as the same vectors are not normalized there.