### PR TITLE
Update Eigen git source

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "3rdparty/Eigen"]
 	path = 3rdparty/Eigen
-	url = https://github.com/eigenteam/eigen-git-mirror.git
+	url = https://gitlab.com/libeigen/eigen.git
 [submodule "3rdparty/stb"]
 	path = 3rdparty/stb
 	url = https://github.com/nothings/stb.git


### PR DESCRIPTION
From [old Eigen repo](https://github.com/eigenteam/eigen-git-mirror) :
> Eigen's official git repository have been moved to https://gitlab.com/libeigen/eigen
> For convenience, this deprecated mirror repository will be kept as is for a short period of time before being deleted.
> So please update your git clones & submodules to https://gitlab.com/libeigen/eigen.git as soon as possible.
> Also note that it is not possible keep it sync with the new official git repository because the hashes do not match.