### PR TITLE
Automaticaly find Eigen3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,19 +94,31 @@ endif(OpenGR_USE_CHEALPIX)
 
 ## Eigen: automatic configuration:
 ##  1. if EIGEN3_INCLUDE_DIR is set, use it directly
-##  2. if any, and version >= 3.3.x, use system version
-##  3. otherwise, download (if required) and use submodule
+##  2. if any, use environement variable
+##  3. if any, and version >= 3.3.x, use system version
+##  4. otherwise, download (if required) and use submodule
 if( NOT EIGEN3_INCLUDE_DIR )
-    find_package(Eigen3 QUIET)
-    if( (NOT Eigen3_FOUND) OR EIGEN_VERSION_NUMBER VERSION_LESS 3.3 )
+    find_path(EIGEN3_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
+        HINTS ENV EIGEN3_INC_DIR
+              ENV EIGEN3_DIR
+        PATHS Eigen/Core
+              /usr/local/include
+              /usr/include
+        PATH_SUFFIXES include eigen3 eigen
+        DOC "Directory containing the Eigen3 header files"
+    )
+    if( NOT EIGEN3_INCLUDE_DIR )
+        find_package(Eigen3 QUIET)
+        if( (NOT Eigen3_FOUND) OR EIGEN_VERSION_NUMBER VERSION_LESS 3.3 )
 
-        set(EIGEN3_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/3rdparty/Eigen")
+            set(EIGEN3_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/3rdparty/Eigen")
 
-        if( NOT EXISTS ${EIGEN3_INCLUDE_DIR}/signature_of_eigen3_matrix_library )
-            execute_process(COMMAND git submodule update --init -- ${EIGEN3_INCLUDE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-        endif( NOT EXISTS ${EIGEN3_INCLUDE_DIR}/signature_of_eigen3_matrix_library )
-    endif()
+            if( NOT EXISTS ${EIGEN3_INCLUDE_DIR}/signature_of_eigen3_matrix_library )
+                execute_process(COMMAND git submodule update --init -- ${EIGEN3_INCLUDE_DIR}
+                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+            endif( NOT EXISTS ${EIGEN3_INCLUDE_DIR}/signature_of_eigen3_matrix_library )
+        endif()
+    endif( NOT EIGEN3_INCLUDE_DIR )
 endif( NOT EIGEN3_INCLUDE_DIR )
 include_directories(${EIGEN3_INCLUDE_DIR})
 message(STATUS "Eigen3 root path: ${EIGEN3_INCLUDE_DIR}")


### PR DESCRIPTION
Now we have to set the CMake variable `EIGEN3_INCLUDE_DIR` manually when installing OpenGR on Windows.  
It would be simpler to use the environment variable `EIGEN3_INC_DIR` added when installing Eigen.  

To make this changes, I was inspired by the [FindEigen3.cmake](https://github.com/CGAL/cgal/blob/master/Installation/cmake/modules/FindEigen3.cmake) file from CGAL.  
I didn't take the whole file which is very complete and secure, but only the part that find Eigen path.  

I was not able to test these modifications on Linux. So it should be done before merge.  

**Note 1:**  
I'm not sure that `find_package(Eigen3 QUIET)` is useful in the OpenGR's `CMakeList.txt` file, because Eigen3 doesn't provide a `Eigen3Config.cmake` file, so find_package() will never find Eigen.  
CGAL can use `find_package(Eigen3)` because they provide themselves a `FindEigen3.cmake` file, which is not the case here.  

**Note 2:**  
The Eigen3 download link is still deprecated, see [pull 82](https://github.com/STORM-IRIT/OpenGR/pull/82)
