### PR TITLE
io addition only if OpenGR_COMPILE_APPS is set to TRUE

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required (VERSION 3.3)
 project (OpenGR-Apps LANGUAGES CXX)
 
-add_subdirectory(io)
-
 
 find_package(OpenMP)
 set(OpenGRAppsDeps)
@@ -14,6 +12,7 @@ endif()
 
 
 if(OpenGR_COMPILE_APPS)
+    add_subdirectory(io)
     add_subdirectory(Super4PCS)
     add_subdirectory(PCLWrapper)
     add_subdirectory(ExtPointBinding)


### PR DESCRIPTION
io fails to compile if both

- OpenGR_COMPILE_APPS set to FALSE
- STB is missing

io should only be added if apps build is requested by user